### PR TITLE
[Media] Mute/unmute video given a range of seconds

### DIFF
--- a/app/src/main/java/com/example/mediasoundfilter/ui/MediaSoundFilterApp.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/MediaSoundFilterApp.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.mediasoundfilter.ui.nav.AuthNavHost
 import com.example.mediasoundfilter.ui.nav.MediaSoundFilterNavHost
 import com.example.mediasoundfilter.ui.screens.auth.AuthViewModel
+import com.example.mediasoundfilter.ui.screens.media.MediaViewModel
 import com.example.mediasoundfilter.ui.screens.upload.UploadViewModel
 
 @Composable
@@ -19,10 +20,11 @@ fun MediaSoundFilterApp() {
     val authUiState = authViewModel.authUiState.collectAsState()
 
     val uploadViewModel: UploadViewModel = viewModel()
+    val mediaViewModel: MediaViewModel = viewModel()
 
     //check if logged in, navigate to right page
     if(authUiState.value.currentUser != null){
-        MediaSoundFilterNavHost(uploadViewModel, navController)
+        MediaSoundFilterNavHost(uploadViewModel, mediaViewModel, navController)
     }
     else{
         AuthNavHost(authViewModel, navController)

--- a/app/src/main/java/com/example/mediasoundfilter/ui/nav/MediaSoundFilterNavHost.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/nav/MediaSoundFilterNavHost.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.mediasoundfilter.ui.screens.account.AccountScreen
 import com.example.mediasoundfilter.ui.screens.media.MediaScreen
+import com.example.mediasoundfilter.ui.screens.media.MediaViewModel
 import com.example.mediasoundfilter.ui.screens.search.SearchScreen
 import com.example.mediasoundfilter.ui.screens.upload.UploadScreen
 import com.example.mediasoundfilter.ui.screens.upload.UploadViewModel
@@ -13,6 +14,7 @@ import com.example.mediasoundfilter.ui.screens.upload.UploadViewModel
 @Composable
 fun MediaSoundFilterNavHost(
     uploadViewModel: UploadViewModel,
+    mediaViewModel: MediaViewModel,
     navController: NavHostController
 ) {
    NavHost(
@@ -30,7 +32,7 @@ fun MediaSoundFilterNavHost(
        }
        composable("media/{videoId}") { backStackEntry ->
            val videoId = backStackEntry.arguments?.getString("videoId")
-           MediaScreen(navController, videoId)
+           MediaScreen(mediaViewModel, navController, videoId)
        }
    }
 }

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/media/MediaScreen.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/media/MediaScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.example.mediasoundfilter.R
@@ -24,7 +25,8 @@ import com.example.mediasoundfilter.ui.components.YoutubePlayerComposeView
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MediaScreen(navController: NavController, videoId: String?) {
+fun MediaScreen(mediaViewModel: MediaViewModel, navController: NavController, videoId: String?) {
+
     Scaffold(
         content = { padding ->
             Column(
@@ -32,7 +34,7 @@ fun MediaScreen(navController: NavController, videoId: String?) {
                     .padding(padding)
             ) {
                 if (videoId != null) {
-                    YoutubePlayerComposeView(videoId) //check if this can have a content desc
+                    YoutubePlayerComposeView(videoId, mediaViewModel.getMuteTimes()) //check if this can have a content desc
                 }
 
                 Column(
@@ -79,5 +81,5 @@ fun MediaScreen(navController: NavController, videoId: String?) {
 @Preview(showBackground = true)
 @Composable
 fun MediaScreenPreview() {
-    MediaScreen(rememberNavController(), null)
+    MediaScreen(viewModel(), rememberNavController(), null)
 }

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/media/MediaViewModel.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/media/MediaViewModel.kt
@@ -1,0 +1,13 @@
+package com.example.mediasoundfilter.ui.screens.media
+
+import androidx.lifecycle.ViewModel
+
+class MediaViewModel : ViewModel() {
+
+    fun getMuteTimes(): List<Pair<Double, Double>>{
+        //return listOf(Pair(0.0, 10.0), Pair(20.0, 30.0))
+        //return listOf(Pair(0.0, 2.13), Pair(4.1567, 5.0), Pair(6.0, 8.0), Pair(7.5679, 8.0))
+        return listOf(Pair(0.0, 2.13), Pair(4.1567, 5.0), Pair(6.0, 8.0), Pair(9.0, 11.5))
+    }
+
+}


### PR DESCRIPTION
Closes #24 

- Added onCurrentSecond and onStateChange to YoutubePlayerComposeView. onCurrentSecond handles muting the video once when the current second falls in a mute range, and unmuting once when the current second falls out of the mute range. onStateChange sets the current play status and allows onCurrentSecond to only mute/unmute if video is playing
- Added a MediaViewModel to get the mute ranges
- Updated MediaScreen to take a MediaViewModel
- Updated YoutubePlayerComposeView to take a list of pairs of doubles