### PR TITLE
[Sounds] Add mute sound selection page before viewing video

### DIFF
--- a/app/src/main/java/com/example/mediasoundfilter/ui/components/AdaptableGrid.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/components/AdaptableGrid.kt
@@ -1,0 +1,41 @@
+package com.example.mediasoundfilter.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import com.example.mediasoundfilter.ui.screens.upload.UploadViewModel
+
+@Composable
+fun AdaptableGrid(rowSize: Int, sounds: List<String>, uploadViewModel: UploadViewModel) {
+
+    val uploadUiState = uploadViewModel.uploadUiState.collectAsState()
+
+    sounds.chunked(rowSize).forEach{ group ->
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceAround
+        ){
+            group.forEach { item ->
+                Row(Modifier.weight(1f)){
+                    RadioButton(
+                        selected = (uploadUiState.value.selectedSounds[item] ?: false),
+                        onClick = {
+                            uploadViewModel.setSelectedSounds(item)
+                        }
+                    )
+                    Text(item)
+                }
+            }
+
+            if(group.size < rowSize){
+                Box(Modifier.weight(1f))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/mediasoundfilter/ui/components/ExpandableCard.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/components/ExpandableCard.kt
@@ -1,0 +1,56 @@
+package com.example.mediasoundfilter.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ExpandableCard(
+    title: String,
+    dropdownContent: @Composable () -> Unit
+) {
+    var expanded by remember {mutableStateOf(false)}
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp)
+            .animateContentSize()
+    ){
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ){
+            Text(title)
+            IconButton(onClick = {expanded = !expanded}){
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.rotate(if(expanded) 180f else 0f)
+                )
+            }
+        }
+
+        if(expanded){
+            dropdownContent()
+        }
+
+    }
+}

--- a/app/src/main/java/com/example/mediasoundfilter/ui/nav/MediaSoundFilterNavHost.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/nav/MediaSoundFilterNavHost.kt
@@ -8,6 +8,7 @@ import com.example.mediasoundfilter.ui.screens.account.AccountScreen
 import com.example.mediasoundfilter.ui.screens.media.MediaScreen
 import com.example.mediasoundfilter.ui.screens.media.MediaViewModel
 import com.example.mediasoundfilter.ui.screens.search.SearchScreen
+import com.example.mediasoundfilter.ui.screens.upload.SoundsScreen
 import com.example.mediasoundfilter.ui.screens.upload.UploadScreen
 import com.example.mediasoundfilter.ui.screens.upload.UploadViewModel
 
@@ -29,6 +30,9 @@ fun MediaSoundFilterNavHost(
        }
        composable("search") {
            SearchScreen(navController)
+       }
+       composable("sounds"){
+           SoundsScreen(uploadViewModel, navController)
        }
        composable("media/{videoId}") { backStackEntry ->
            val videoId = backStackEntry.arguments?.getString("videoId")

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/media/MediaScreen.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/media/MediaScreen.kt
@@ -1,25 +1,18 @@
 package com.example.mediasoundfilter.ui.screens.media
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.scale
-import androidx.compose.ui.res.stringArrayResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import com.example.mediasoundfilter.R
 import com.example.mediasoundfilter.ui.components.NavBar
 import com.example.mediasoundfilter.ui.components.YoutubePlayerComposeView
 
@@ -48,29 +41,6 @@ fun MediaScreen(mediaViewModel: MediaViewModel, navController: NavController, vi
                         text = "Uploaded By Test",
                         fontSize = 16.sp
                     )
-                }
-                Column(
-                    modifier = Modifier.padding(10.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.mute_sounds),
-                        fontSize = 20.sp
-                    )
-                    //for each loop; some sort of flexbox type layout where only two blocks will populate
-                    //each row
-                    val triggerSounds = stringArrayResource(R.array.trigger_sounds)
-                    for (i in triggerSounds.indices) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            RadioButton(
-                                selected = false,
-                                onClick = {},
-                                modifier = Modifier.scale(.75f)
-                            )
-                            Text(triggerSounds.getOrNull(i).toString())
-                        }
-                    }
                 }
             }
         },

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/SoundsScreen.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/SoundsScreen.kt
@@ -1,0 +1,49 @@
+package com.example.mediasoundfilter.ui.screens.upload
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.example.mediasoundfilter.R
+import com.example.mediasoundfilter.ui.components.AdaptableGrid
+import com.example.mediasoundfilter.ui.components.ExpandableCard
+
+@Composable
+fun SoundsScreen(uploadViewModel: UploadViewModel, navController: NavController) {
+
+    val uploadUiState = uploadViewModel.uploadUiState.collectAsState()
+    val videoId = uploadUiState.value.videoId
+
+    uploadViewModel.setSounds()
+
+    Column(){
+        Text(stringResource(R.string.mute_sounds_title) + " " + "placeholder" + "?")
+
+        val soundCategories = uploadUiState.value.muteSounds.keys
+        for (cat in soundCategories){
+            ExpandableCard(cat){
+                uploadUiState.value.muteSounds[cat]?.let { AdaptableGrid(2, it, uploadViewModel) }
+            }
+        }
+
+        Button(
+            content = {Text(stringResource(R.string.watch_video))},
+            onClick = {
+                navController.navigate("media/$videoId")
+                uploadViewModel.resetState()
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SoundsScreenPreview(){
+    SoundsScreen(viewModel(), rememberNavController())
+}

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/UploadScreen.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/UploadScreen.kt
@@ -46,8 +46,7 @@ fun UploadScreen(uploadViewModel: UploadViewModel, navController: NavHostControl
     val videoId = uploadUiState.value.videoId
     LaunchedEffect(videoId){
         videoId?.let{
-            navController.navigate("media/$it")
-            uploadViewModel.resetState()
+            navController.navigate("sounds")
         }
     }
 

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/UploadUiState.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/UploadUiState.kt
@@ -2,5 +2,7 @@ package com.example.mediasoundfilter.ui.screens.upload
 
 data class UploadUiState (
     val videoId: String? = null,
-    val linkError: String? = null
+    val linkError: String? = null,
+    val muteSounds: Map<String, List<String>> = emptyMap(),
+    val selectedSounds: Map<String, Boolean> = emptyMap()
 )

--- a/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/UploadViewModel.kt
+++ b/app/src/main/java/com/example/mediasoundfilter/ui/screens/upload/UploadViewModel.kt
@@ -66,4 +66,31 @@ class UploadViewModel: ViewModel() {
     fun clearLinkError(){
         _uploadUiState.value = _uploadUiState.value.copy(linkError = null)
     }
+
+    fun setSounds(){
+        val speechList = listOf("Babbling", "Shouting", "Whispering", "Crying", "Baby Crying",
+            "Whimpering", "Sighing", "Singing", "Humming", "Groaning", "Grunting", "Whistling",
+            "Breathing", "Wheezing", "Snoring", "Gasping", "Panting", "Coughing", "Throat Clearing",
+            "Eating", "Gargling", "Burping", "Hiccuping")
+        val humanList = listOf("Sneezing", "Sniffing", "Farting")
+        val movementList = listOf("Footsteps", "Finger Snapping", "Clapping")
+        val environmentalList = listOf("Knocking", "Slamming", "Tapping", "Squeaking", "Drawer/Cupboard",
+            "Pots and Pans", "Silverware", "Vacuum Cleaner", "Typing", "Clock", "Filing", "Clink",
+            "Squish", "Clicking", "TV")
+        val phoneList = listOf("Siren", "Phone Ringing", "Phone Dialing", "Dial Tone", "Alarm Clock",
+            "Buzzer", "Foghorn", "Whistle", "Beep", "Ding")
+        val sounds = mapOf("Speech/Mouth" to speechList, "Other Human Noises" to humanList,
+            "Human Movement" to movementList, "Environmental Movement" to environmentalList,
+            "Phone/Alarms" to phoneList)
+
+        _uploadUiState.value = _uploadUiState.value.copy(muteSounds = sounds)
+    }
+
+    fun setSelectedSounds(item: String){
+        val newSelections = _uploadUiState.value.selectedSounds.toMutableMap()
+        newSelections[item] = !(newSelections[item] ?: false)
+
+        _uploadUiState.value = _uploadUiState.value.copy(selectedSounds = newSelections)
+    }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="upload">Upload</string>
     <string name="saved">Saved Videos</string>
     <string name="mute_sounds">Mute Sounds</string>
+    <string name="mute_sounds_title">Which sounds would you like to mute from</string>
     <string name="arrow">Back Arrow</string>
     <string name="search">Search</string>
     <string name="account">Account</string>
@@ -19,11 +20,5 @@
     <string name="email">Email</string>
     <string name="confirm_password">Confirm Password</string>
     <string name="link">Link</string>
-
-    <string-array name="trigger_sounds">
-        <item>Throat Clearing</item>
-        <item>Typing</item>
-        <item>Chewing</item>
-        <item>Yawning</item>
-    </string-array>
+    <string name="watch_video">Watch Video</string>
 </resources>


### PR DESCRIPTION
Closes #29 

- Added SoundsScreen to display all available mute sounds and let user select the ones they wish to mute
- Added AdaptableGrid and ExpandableCard components for use in SoundsScreen
- Removed mute sounds from media screen
- Added SoundsScreen to navhost and redirected upload to go to sounds and then to media
- Added mute sounds and selected sounds to upload UI state
- Added an uploadViewModel function to manually set the sounds available to mute until API is available